### PR TITLE
Makefile.uk: Fix build-time infinite loop

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -80,7 +80,7 @@ $(LIBCLICK_BUILD)/.configured: $(LIBCLICK_BUILD)/.cpfromtodevs
 	       $(TOUCH) $@)
 
 # Generate element build rules using click-buildtool
-$(LIBCLICK_BUILD)/.elementsmk: $(LIBCLICK_BUILD)/.configured $(UK_CONFIG_OUT)
+$(LIBCLICK_BUILD)/.elementsmk: $(LIBCLICK_BUILD)/.configured
 	$(call verbose_cmd,ELEMMK,libclick: $(notdir $@),\
 	       cd $(LIBCLICK_ELEMENTS_DIR) && echo "$(LIBCLICK_FILTERED_ELEM_DIRS)" | $(LIBCLICK_BUILDTOOL) findelem -r unikraft -X $(LIBCLICK_BUILD)/elements.exclude | grep -E "^[^#]" | awk '{print "LIBCLICK_SRCS-y += $$(LIBCLICK_EXTRACTED)/elements/" $$1}' > $@)
 


### PR DESCRIPTION
This PR removes the dependency on the $(UK_CONFIG_OUT) file, which is not necessary for `lib-click` to build and actually causes an infinite loop in the build process.