### PR TITLE
Update lib click to the latest Unikraft version

### DIFF
--- a/click.cc
+++ b/click.cc
@@ -421,8 +421,9 @@ int CLICK_MAIN(int argc, char **argv)
 		on_router((*path + strlen(PATH_ROOT)), val);
 	}
 #else
-	router = uk_thread_create("click-router", router_thread, 0);
-	uk_thread_wait(router);
+	router = uk_sched_thread_create(uk_sched_current(), router_thread, 0, "click-router");
+	while (!uk_thread_is_exited(router))
+		uk_sched_yield();
 #endif
 	LOG("Shutting down...");
 

--- a/click.cc
+++ b/click.cc
@@ -152,7 +152,7 @@ static String *
 get_config()
 {
 	String *cfg = new String(macaddr_preamble);
-	struct ukplat_memregion_desc img;
+	struct ukplat_memregion_desc *img;
 	char *cstr;
 	size_t cstr_len;
 
@@ -160,8 +160,8 @@ get_config()
 
 	/* First, try initrd */
 	if (ukplat_memregion_find_initrd0(&img) >= 0) {
-		cstr = (char *)img.base;
-		cstr_len = img.len;
+		cstr = (char *)img->pbase;
+		cstr_len = img->len;
 	} else {
 		/* If we can't find a config: use a fallback one statically
 		 * compiled in.

--- a/patches/0003-glue.cc-Change-__assert_fail-function-signature.patch
+++ b/patches/0003-glue.cc-Change-__assert_fail-function-signature.patch
@@ -1,0 +1,29 @@
+From 33cee463dd74661440551b676104107df07a193b Mon Sep 17 00:00:00 2001
+From: Stefan Jumarea <stefanjumarea02@gmail.com>
+Date: Fri, 8 Sep 2023 15:01:00 +0300
+Subject: [PATCH] glue.cc: Change __assert_fail function signature
+
+Musl uses int as the line type, instead of unsigned int, which will lead
+to conflicting definitions.
+
+Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>
+---
+ lib/glue.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/glue.cc b/lib/glue.cc
+index e9e14149e..ec37da7d0 100644
+--- a/lib/glue.cc
++++ b/lib/glue.cc
+@@ -782,7 +782,7 @@ extern "C" {
+ void
+ __assert_fail(const char *__assertion,
+ 	      const char *__file,
+-	      unsigned int __line,
++	      int __line,
+ 	      const char *__function)
+ {
+   click_chatter("assertion failed %s %s %d %s\n",
+-- 
+2.39.2
+

--- a/stubs.cc
+++ b/stubs.cc
@@ -1,4 +1,5 @@
 #include <errno.h>
+#include <uk/essentials.h>
 #include <click/config.h>
 #include <click/error.hh>
 #include <click/string.hh>

--- a/unikraft/fromdevice.cc
+++ b/unikraft/fromdevice.cc
@@ -123,7 +123,7 @@ FromDevice::initialize(ErrorHandler *errh)
 	uk_pr_info("FromDevice::initialize %p device %p state %d\n",
 			this, _dev, _dev->_data->state);
 	uk_netdev_info_get(_dev, &dinf);
-	rx_conf.s = uk_sched_get_default();
+	rx_conf.s = uk_sched_current();
 	rx_conf.a = uk_alloc_get_default();
 	rx_conf.callback = click_fromdevice_rx_callback;
 	rx_conf.callback_cookie = (void *)(this);


### PR DESCRIPTION
You can test this pr by running [`app-click`](https://github.com/unikraft/app-click) with the following commands:

```bash
sudo ip link set dev virbr0 down 2> /dev/null
sudo ip link del dev virbr0 2> /dev/null
sudo ip link add dev virbr0 type bridge
sudo ip address add 172.44.0.1/24 dev virbr0
sudo ip link set dev virbr0 up

sudo qemu-system-x86_64 \
    -netdev bridge,id=en0,br=virbr0 -device virtio-net-pci,netdev=en0 \
    -append "netdev.ipv4_addr=172.44.0.2 netdev.ipv4_gw_addr=172.44.0.1 netdev.ipv4_subnet_mask=255.255.255.0 --" \
    -kernel build/click_qemu-x86_64 \
    -initrd helloworld.click \
    -nographic

Powered by
o.   .o       _ _               __ _
Oo   Oo  ___ (_) | __ __  __ _ ' _) :_
oO   oO ' _ `| | |/ /  _)' _` | |_|  _)
oOo oOO| | | | |   (| | | (_) |  _) :_
 OoOoO ._, ._:_:_,\_._,  .__,_:_, \___)
      Prometheus 0.14.0~c66cdc68-custom
[    0.121219] ERR:  [libuknetdev] <netdev.c @  235> PROBING
[    0.121758] ERR:  [libuknetdev] <netdev.c @  338> TEST
Received config (length 144):
define($MAC0 52:54:00:12:34:56);
/* End unikraft-provided MAC preamble */
FromDevice
  -> Print('Hello, World!')
  -> EtherMirror
  -> ToDevice;
Hello, World!:   90 | 33330000 0016feff 258ea864 86dd6000 00000024 00010000
Hello, World!:  130 | 33330000 00160af9 d92a3d5f 86dd6000 0000004c 0001fe80
[router_thread:200] Starting driver...


Hello, World!:   90 | 33330000 0016feff 258ea864 86dd6000 00000024 00010000
Hello, World!:   86 | 3333ff8e a864feff 258ea864 86dd6000 00000020 3aff0000
Hello, World!:   90 | 33330000 0016feff 258ea864 86dd6000 00000024 0001fe80
```